### PR TITLE
Confirmation rejection

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -5,7 +5,7 @@
   height: 100vh;
   background-attachment: fixed;
   margin-bottom: 0px;
-  margin-top: -19px;
+  margin-top: 0px;
 }
 
 .banner img {

--- a/app/assets/stylesheets/components/_basket.scss
+++ b/app/assets/stylesheets/components/_basket.scss
@@ -50,7 +50,7 @@
   }
 
   .basket-no-items {
-    padding: 10px;
+    padding: 0px;
     display: flex;
     justify-content: space-around;
     align-item: center;
@@ -130,7 +130,7 @@
     margin-top: 10px;
     color: #FECD18;
     font-weight: bold;
-    padding: 10px;
+    padding: 0px;
     display: flex;
     justify-content: space-around;
     align-items: center;

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -325,3 +325,16 @@
   -o-animation: reject 1500ms infinite;
   animation: reject 1500ms infinite;
 }
+
+
+.active_order_link {
+  position: absolute;
+  z-index: 0.9;
+  top: 60px;
+  right: 0px;
+  width: auto;
+  border-radius: 0;
+}
+
+
+

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -68,9 +68,8 @@
 
 .add-to-basket-btn {
   padding: 7px 20px;
-  background-color: #495365;
+  background-color: #FECD1A;
   border-radius: 0 0 10px 10px;
-  text-decoration: none;
   width: 100%;
   margin-top: 10px;
   display: flex;
@@ -78,10 +77,17 @@
   justify-content: space-around;
   position: absolute;
   bottom: 0px;
+  font-weight: 500;
   a {
-    color: white;
-    font-weight: bold;
+    color: #353B48 ;
+    text-decoration: none;
   }
+}
+
+.add-to-basket-btn:hover {
+  text-decoration: none;
+  font-weight: bold;
+  color: #353B48;
 }
 
 // Add-to-basket-btn media query
@@ -104,10 +110,10 @@
 
 @media only screen and (max-width: 429px) {
   .btn-app {
-  height: 30px;
-  width: auto;
-  margin-right: 5px;
-}
+    height: 30px;
+    width: auto;
+    margin-right: 5px;
+  }
 }
 
 .btn-app:link,
@@ -153,20 +159,21 @@
 
 .btn-basket {
   padding: 5px 10px;
-  margin-left: 50px;
-  line-height: 50px;
+  margin-left: 0px;
+  width: 100%;
+  line-height: 25px;
   font-weight: 500;
   font-size: 15px;
   text-decoration: none;
-  border-radius: 5px;
+  border-radius: 0  0 5px 5px;
   background-color: #FECD1A;
-  border: 1px solid #FECD1A;
   color: #353B48;
   transition: 0.3s;
+  text-align: center;
 }
 
 .btn-basket:hover,
-.btn-basket:active, {
+.btn-basket:active {
   text-decoration: none;
   font-weight: bold;
   color: #353B48;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -30,7 +30,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 1;
+  z-index: 2;
 }
 
 .navbar-lewagon .navbar-collapse {

--- a/app/assets/stylesheets/pages/_confirmation.scss
+++ b/app/assets/stylesheets/pages/_confirmation.scss
@@ -12,11 +12,11 @@
 } */
 
 
-.pulsate {
-    -webkit-animation: pulsate 1.2s ease-out;
-    -webkit-animation-iteration-count: infinite;
-    opacity: 0.5;
-}
+// .pulsate {
+//     -webkit-animation: pulsate 1.2s ease-out;
+//     -webkit-animation-iteration-count: infinite;
+//     opacity: 0.5;
+// }
 @-webkit-keyframes pulsate {
     0% {
         opacity: 0.6;
@@ -59,6 +59,8 @@
   .active {
     color: orange;
     font-size: 30px;
+    -webkit-animation: pulsate 1.2s ease-out;
+    -webkit-animation-iteration-count: infinite;
   }
 
   #go-back {

--- a/app/assets/stylesheets/pages/_confirmation.scss
+++ b/app/assets/stylesheets/pages/_confirmation.scss
@@ -1,34 +1,3 @@
-// .pending {
-//   color: orange;
-// }
-
-// .wait {
-//   color: #c6c4c4;
-//   font-size: 2rem;
-// }
-
-/* .hide {
-  display: none;
-} */
-
-
-// .pulsate {
-//     -webkit-animation: pulsate 1.2s ease-out;
-//     -webkit-animation-iteration-count: infinite;
-//     opacity: 0.5;
-// }
-@-webkit-keyframes pulsate {
-    0% {
-        opacity: 0.6;
-    }
-    50% {
-        opacity: 1.0;
-    }
-    100% {
-        opacity: 0.6;
-    }
-}
-
 .test_scroll {
   margin-bottom: 300px;
   #display {
@@ -59,14 +28,11 @@
   .active {
     color: orange;
     font-size: 30px;
-    -webkit-animation: pulsate 1.2s ease-out;
-    -webkit-animation-iteration-count: infinite;
   }
 
   #go-back {
     display: none;
   }
-
 }
 
 .hidden {

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,6 +5,8 @@ class OrdersController < ApplicationController
     order = Order.find_by(user: current_user, item: item, collected: false, status: "pending")
     if active_orders.any? && active_orders.last.item.store != item.store
       redirect_to store_path(item.store), notice: "You cannot add from two different stores."
+    elsif current_user.orders.accepted.any? || current_user.orders.checkout.any?
+      redirect_to store_path(item.store), notice: "You already have an active order."
     elsif order
       order.quantity += 1
       order.save

--- a/app/javascript/plugins/confirmation_page.js
+++ b/app/javascript/plugins/confirmation_page.js
@@ -37,7 +37,13 @@ const find_status = () => {
             scroll_container.children[0].classList.remove('active');
             scroll_container.children[1].classList.remove('active');
             scroll_container.children[2].classList.add('active');
-            scroll_container.children[3].style.display = "inline-block";
+            scroll_container.children[4].style.display = "inline-block";
+          } else if (data.status === "rejected") {
+            scroll_container.children[0].style.display = "none";
+            scroll_container.children[1].style.display = "none";
+            scroll_container.children[2].style.display = "none";
+            scroll_container.children[3].style.display = "block";
+            scroll_container.children[4].style.display = "inline-block";
           }
         });
     }, 2000);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
 
     <div class="d-flex flex-column min-vh-100">
       <%= render 'shared/navbar' %>
+      <%= render 'shared/active-order-link' %>
       <%= render 'shared/flashes' %>
       <article class="flex-grow-1 background-shade">
         <%= yield %>

--- a/app/views/orders/confirmation.html.erb
+++ b/app/views/orders/confirmation.html.erb
@@ -4,10 +4,10 @@
 <div class="test_scroll">
   <section id="display">
     <div id="container">
-      <div class="mt-4 confirmation_item active"><i class="far fa-clock"></i><%=@store.name%> will confirm your order... </div>
+      <div class="mt-4 confirmation_item active"><i class="far fa-clock"></i><%=@store.name%> will confirm your order...</div>
       <div class="mt-4 confirmation_item"><i class="far fa-check-circle"></i><%=@store.name%> has confirmed your order... </div>
       <div class="mt-4 confirmation_item"><i class="fas fa-walking"></i>Your order has been marked as collected! </div>
-      <div class="confirmation_item hidden " style="margin-top: -40px">We apologise but this store has declined your order. <br> Return home for more options.</div>
+      <div class="confirmation_item hidden " style="margin-top: -20px">We apologise but this store has declined your order. <br> Return to feed for more options.</div>
       <%= link_to "Go back to my feed", stores_path, class: "mt-4 btn btn-full", id: "go-back" %>
     </div>
   </section>

--- a/app/views/orders/confirmation.html.erb
+++ b/app/views/orders/confirmation.html.erb
@@ -7,9 +7,8 @@
       <div class="mt-4 confirmation_item active"><i class="far fa-clock"></i><%=@store.name%> will confirm your order... </div>
       <div class="mt-4 confirmation_item"><i class="far fa-check-circle"></i><%=@store.name%> has confirmed your order... </div>
       <div class="mt-4 confirmation_item"><i class="fas fa-walking"></i>Your order has been marked as collected! </div>
-      <!-- <div class="mt-4 btn btn-primary" id="go-back">Go back to my feed</div> -->
-      <%= link_to "Go back to my feed", stores_path, class: "mt-4 btn btn-primary", id: "go-back" %>
-      <div class="mt-4 btn btn-primary hidden">Show this code to owner</div>
+      <div class="confirmation_item hidden " style="margin-top: -40px">We apologise but this store has declined your order. <br> Return home for more options.</div>
+      <%= link_to "Go back to my feed", stores_path, class: "mt-4 btn btn-full", id: "go-back" %>
     </div>
   </section>
 </div>

--- a/app/views/shared/_active-order-link.html.erb
+++ b/app/views/shared/_active-order-link.html.erb
@@ -1,0 +1,8 @@
+<% if current_user.orders.checkout.any? || current_user.orders.accepted.any? %>
+  <% if current_user.orders.checkout.any? %>
+    <% store = current_user.orders.checkout.first.store %>
+  <% elsif current_user.orders.accepted.any? %>
+    <% store = current_user.orders.accepted.first.store %>
+  <% end %>
+  <%= link_to "You have current active order", confirmation_store_path(store), class: "edit-btn active_order_link" %>
+<% end %>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -49,9 +49,9 @@
           <div class="item-name" ><%= item.name %></div>
           <s>Original Price:<%= number_to_currency(item.price, unit: "£") %></s>
           <br>
-          <strong id="new-price"> New Price: <%= number_to_currency(item.discounted_price, unit: "£") %></strong>
-          <%= link_to "Add to Basket", create_order_path(item.id), method: :post, class: "btn-basket" %>
+          <div><strong id="new-price"> New Price: <%= number_to_currency(item.discounted_price, unit: "£") %></strong></div>
         </div>
+        <%= link_to "Add to Basket", create_order_path(item.id), method: :post, class: "btn-basket" %>
     </div>
     <% end %>
     </div>

--- a/app/views/stores/show.html.erb
+++ b/app/views/stores/show.html.erb
@@ -22,7 +22,17 @@
   <% flash.each do |type, msg| %>
   <div class="p-3 m-2 alert-danger my-alert">
     <span><%= msg %></span>
-    <span>Go back to: <%= link_to "#{@orders.last.item.store.name}", store_path(@orders.last.item.store), class: ".alert-link"%></span>
+    <% if @orders.empty? %>
+      <!-- This means there are no pending orders -->
+      <% if current_user.orders.checkout.any? %>
+        <% store = current_user.orders.checkout.first.store %>
+      <% elsif current_user.orders.accepted.any? %>
+        <% store = current_user.orders.accepted.first.store %>
+      <% end %>
+      <span><%= link_to "Back to confirmation page", confirmation_store_path(store), class: ".alert-link"%></span>
+    <% else %>
+      <span>Go back to: <%= link_to "#{@orders.last.item.store.name}", store_path(@orders.last.item.store), class: ".alert-link"%></span>
+    <% end %>
   </div>
   <% end %>
   <div class="show-items-grid">


### PR DESCRIPTION
Okay so this branch contains more than it should. Will provide photos below but in a nutshell:
1. Added the rejection clause to the confirmation page
2. Added a active order button to display on all pages that leads back to the confirmation page (only when you  have an active 
  order)
3. Adjusted styling of some of the elements on confirmation page
4. Added the error messages if the user tries to create an order with an already active order
5. Changed the cards on the show and index pages so that they are consistent

Photos:
1. 
<img width="1114" alt="Screenshot 2020-12-02 at 14 54 33" src="https://user-images.githubusercontent.com/68656882/100888681-4c0ff480-34ae-11eb-9f56-df433f333105.png">

2. 
<img width="1114" alt="Screenshot 2020-12-02 at 14 55 06" src="https://user-images.githubusercontent.com/68656882/100888773-6053f180-34ae-11eb-9ee8-f80ff968dda8.png">

4. 
<img width="1114" alt="Screenshot 2020-12-02 at 14 55 50" src="https://user-images.githubusercontent.com/68656882/100888876-795ca280-34ae-11eb-94fb-fa5e4b41809e.png">

5. 
Card on show page: 
<img width="232" alt="Screenshot 2020-12-02 at 14 56 32" src="https://user-images.githubusercontent.com/68656882/100888988-92fdea00-34ae-11eb-8b56-6c78670245b9.png">
Card on index page: 
<img width="267" alt="Screenshot 2020-12-02 at 14 57 12" src="https://user-images.githubusercontent.com/68656882/100889085-aad56e00-34ae-11eb-98f1-cbc174d00546.png">


