### PR TITLE
fixing index add to basket

### DIFF
--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -56,9 +56,10 @@
                 <br>
                 <strong id="new-price"> New Price: <%= number_to_currency(item.discounted_price, unit: "£") %></strong>
               </div>
-              <%= link_to "Add to Basket", create_order_path(item.id), method: :post, class: "btn-basket" %>
+              <% if current_user != store.user %>
+                <%= link_to "Add to Basket", create_order_path(item.id), method: :post, class: "btn-basket" %>
+              <% end %>
             </div>
-        
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Just noticed that your own store in the index page had the ability to add items from your own store to your basket (when this shouldn't be possible!!!). So i've just put a if/else on the button checking if current user is the store owner and if so then getting rid of the add to basket button. It looks a bit bare but would've broken eventually if left in place!

Looks like this:
<img width="1440" alt="Screenshot 2020-12-03 at 11 44 08" src="https://user-images.githubusercontent.com/68656882/101013864-dd3da480-355c-11eb-9f11-f026c344203f.png">
